### PR TITLE
fix(firebase): index on created at

### DIFF
--- a/src/data/firebase/topic/topicDatabase.ts
+++ b/src/data/firebase/topic/topicDatabase.ts
@@ -34,7 +34,7 @@ export class FirebaseTopicDatabase implements ITopicDatabase {
   }
 
   async findAllSortByCreatedAt(limit: number): Promise<TopicDto[]> {
-    const snapshots = await this.topicsRef().orderByChild('createdAt').limitToLast(limit).once('value');
+    const snapshots = await this.topicsRef().limitToLast(limit).once('value');
     const data: TopicDto[] = [];
     snapshots.forEach((snapshot) => {
       const dto = TopicDto.fromJSON(snapshot.toJSON());


### PR DESCRIPTION
## 概要

### 修正の目的・解決したこと
SDKを通じてクエリを実行すると、
一度データがすべてダウンロードされてしまうので、
Firebaseのルールとしてクエリを実行するように修正した。

### 変更の種類

- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加 
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)

### 関連する Issue
