### PR TITLE
fix(p5): resize canvas size

### DIFF
--- a/src/components/p5/Canvas.tsx
+++ b/src/components/p5/Canvas.tsx
@@ -35,10 +35,8 @@ export const Canvas: React.FC = () => {
   },        [renderRef]);
 
   const setup = (p5: P5Types, canvasParentRef: Element) => {
-    p5.createCanvas(
-        canvasParentRef.clientWidth,
-        canvasParentRef.clientHeight,
-    ).parent(canvasParentRef);
+    const renderer = p5.createCanvas(canvasParentRef.clientWidth, canvasParentRef.clientHeight);
+    renderer.parent(canvasParentRef);
 
     // 壁の描画
     controller.walls.forEach(object => {
@@ -50,11 +48,12 @@ export const Canvas: React.FC = () => {
   };
 
   const draw = (p5: P5Types) => {
-    // キャンバスのサイズ変更 現在のキャンバスサイズとウインドウのサイズが異なれば変更する
-    if (controller.canvas.checkCanvasSize()) {
-      console.log(`canvas is resized\nwidth: ${document.documentElement.clientWidth} px\nheight: ${document.documentElement.clientHeight} px`);
-      p5.resizeCanvas(document.documentElement.clientWidth, document.documentElement.clientHeight);
-      controller.canvas.setSize(document.documentElement.clientWidth, document.documentElement.clientHeight);
+    // キャンバスサイズの更新
+    if (renderRef.current) {
+      controller.canvas.checkResize(renderRef.current, (width, height) => {
+        p5.resizeCanvas(width, height);
+        controller.canvas.setSize(width, height);
+      });
     }
 
     // 背面を白で塗りつぶす

--- a/src/view/matter/models/canvasParameter.ts
+++ b/src/view/matter/models/canvasParameter.ts
@@ -16,9 +16,16 @@ export class CanvasParameter {
     this.height = height;
   }
 
-  /* キャンバスサイズとウィンドウサイズが同じかどうか調べる */
-  checkCanvasSize(): boolean {
-    return (this.width !== document.documentElement.clientWidth)
-        || (this.height !== document.documentElement.clientHeight);
+  /**
+   * キャンバスサイズの変更を検知し、変更があったときのみ、{@param onResize}を呼び出す。
+   * @param parent キャンバスの親要素　この要素のパラメータに基づいて、変更の検知を行う。
+   * @param onResize サイズ変更時に呼び出されるコールバック関数
+   */
+  checkResize(parent: HTMLDivElement, onResize: (width: number, height: number) => void): boolean {
+    const newWidth = parent.clientWidth;
+    const newHeight = parent.clientHeight;
+    const sizeChanged = (this.width !== newWidth) || (this.height !== newHeight);
+    if (sizeChanged) onResize(newWidth, newHeight);
+    return sizeChanged;
   }
 }


### PR DESCRIPTION
## 概要

### 修正の目的・解決したこと
ウィンドウサイズが変更されたときに、
適切にキャンバスサイズが変更されるように修正した。

### スクリーンショット
![image](https://user-images.githubusercontent.com/55840281/112709529-cb15b680-8efd-11eb-8d16-1f1a6db95bc5.png)
`canvas`要素が、親の`div`要素のサイズに合わせて修正されるようになった。

### 変更の種類

- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加 
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)

### 関連する Issue
- close #0
- close #0
- #0