### PR TITLE
fix(p5): keep p5 instance

### DIFF
--- a/src/components/p5/Canvas.tsx
+++ b/src/components/p5/Canvas.tsx
@@ -5,14 +5,14 @@ import { drawVertices } from 'src/view/matter/util/drawVertices';
 import { useMessageState } from 'src/data/redux/message/selector';
 import styled from 'styled-components';
 
-const controller = MatterControllerFactory.create(
-  document.documentElement.clientWidth,
-  document.documentElement.clientHeight,
-);
-
 export const Canvas: React.FC = () => {
   const { messages } = useMessageState();
   const renderRef = useRef<HTMLDivElement>(null);
+
+  const controller = MatterControllerFactory.create(
+    document.documentElement.clientWidth,
+    document.documentElement.clientHeight,
+  );
 
   useEffect(() => {
     if (!messages) return;
@@ -30,8 +30,11 @@ export const Canvas: React.FC = () => {
       p.draw = () => draw(p);
     });
 
+    controller.p5 = p5;
+
     return () => {
       p5.remove();
+      controller.p5 = null;
     };
   }, [renderRef]);
 

--- a/src/view/matter/actors/characterFactory.ts
+++ b/src/view/matter/actors/characterFactory.ts
@@ -16,8 +16,7 @@ const characterColors: string[] = [
 ];
 
 export class CharacterFactory {
-  static create(canvas: CanvasParameter, id: string, text: string): Character {
-    const p5 = new P5Types(() => {});
+  static create(p5: P5Types, canvas: CanvasParameter, id: string, text: string): Character {
     let lines = this.measureTextLength(text, CharacterSize.small, p5);
     let radius: number = CharacterSize.small;
     if (lines > 3) {

--- a/src/view/matter/controllers/matterController.ts
+++ b/src/view/matter/controllers/matterController.ts
@@ -5,9 +5,12 @@ import { Character } from 'src/view/matter/actors/character';
 import { CharacterFactory } from 'src/view/matter/actors/characterFactory';
 import { CanvasParameter } from 'src/view/matter/models/canvasParameter';
 import { MatterListAdapter } from 'src/view/matter/lib/matterListAdapter';
+import P5Types from 'p5';
 
 export class MatterController {
   public readonly adapter: MatterListAdapter;
+
+  public p5: P5Types | null = null;
 
   constructor(
     public readonly engine: Matter.Engine,
@@ -57,7 +60,9 @@ export class MatterController {
             break;
           }
           case 'addButton': {
+            if (!this.p5) break;
             const character = CharacterFactory.create(
+              this.p5,
               this.canvas,
               `${Common.nextId()}`,
               '新しく追加したオブジェクトです',

--- a/src/view/matter/controllers/matterControllerFactory.ts
+++ b/src/view/matter/controllers/matterControllerFactory.ts
@@ -4,7 +4,11 @@ import { MatterController } from 'src/view/matter/controllers/matterController';
 import { CharacterController } from 'src/view/matter/controllers/characterController';
 
 export class MatterControllerFactory {
+  private static _instance: MatterController | null;
+
   static create(windowWidth: number, windowHeight: number): MatterController {
+    if (this._instance) return this._instance;
+
     const engine = Matter.Engine.create();
     const canvas = new CanvasParameter(windowWidth, windowHeight);
 
@@ -29,7 +33,7 @@ export class MatterControllerFactory {
       label: 'shakeAllButton',
     });
 
-    return new MatterController(
+    this._instance = new MatterController(
       engine,
       walls,
       addButton,
@@ -38,6 +42,8 @@ export class MatterControllerFactory {
       characterController,
       canvas,
     );
+
+    return this._instance;
   }
 }
 

--- a/src/view/matter/lib/matterListAdapter.ts
+++ b/src/view/matter/lib/matterListAdapter.ts
@@ -10,7 +10,10 @@ export class MatterListAdapter extends ListAdapter<MessageEntity> {
   }
 
   protected onAddItem(item: MessageEntity): void {
+    const { p5 } = this.controller;
+    if (!p5) return;
     const character = CharacterFactory.create(
+      p5,
       this.controller.canvas,
       item.id,
       item.body,


### PR DESCRIPTION
## 概要

### 修正の目的・解決したこと
p5がインスタンス化されると、
自動的にキャンバスが生成されてしまうので、
MatterControllerにP5インスタンスをもたせるように修正した。

### スクリーンショット
![修正前](https://user-images.githubusercontent.com/55840281/114253652-f2807f00-99e5-11eb-9b90-3ae967520112.png)
![修正後](https://user-images.githubusercontent.com/55840281/114253655-f90ef680-99e5-11eb-99f2-1d9a0436487e.png)

### 変更の種類

- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加 
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)

### 関連する Issue