### PR TITLE
fix(*): added styled-component babel plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -9,6 +9,13 @@ module.exports = {
         root: ['./'],
       },
     ],
+    [
+      "babel-plugin-styled-components",
+      {
+        "ssr": true,
+        "displayName": false,
+      }
+    ],
     'inline-react-svg'
   ],
   env: {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@typescript-eslint/parser": "^4.19.0",
     "babel-plugin-inline-react-svg": "^2.0.1",
     "babel-plugin-module-resolver": "^4.1.0",
+    "babel-plugin-styled-components": "^1.12.0",
     "eslint": "^7.23.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-prettier": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2224,7 +2224,7 @@ babel-plugin-polyfill-regenerator@^0.1.2:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.1.5"
 
-"babel-plugin-styled-components@>= 1":
+"babel-plugin-styled-components@>= 1", babel-plugin-styled-components@^1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.12.0.tgz#1dec1676512177de6b827211e9eda5a30db4f9b9"
   integrity sha512-FEiD7l5ZABdJPpLssKXjBUJMYqzbcNzBowfXDCdJhOpbhWiewapUaY+LZGT8R4Jg2TwOjGjG4RKeyrO5p9sBkA==


### PR DESCRIPTION
## 概要

### 修正の目的・解決したこと
SSR時にstyled-componentのクラス名が衝突してしまう不具合を解消。

### 変更の種類

- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加 
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)

### 関連する Issue
- close #86 