### PR TITLE
fix: redirect to login page

### DIFF
--- a/src/pages/topics/create.tsx
+++ b/src/pages/topics/create.tsx
@@ -18,8 +18,9 @@ type Props = {
 
 const CreateTopicPage = ({ isLoggedIn }: Props) => {
   const router = useRouter();
+
   if (!isLoggedIn) {
-    router.push({
+    router.replace({
       pathname: rootPath.login,
       query: { return_to: `${rootPath.fullPath(rootPath.topicPath.create)}` },
     }).then();


### PR DESCRIPTION
## 概要

### 修正の目的・解決したこと
話題作成ページに入り、認証のためログインページにリダイレクトされた時、
戻るボタンにより、話題作成ページに入る前の画面に遷移できるように修正。

### 変更の種類

- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加 
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)

### 関連する Issue
- close #73 