### PR TITLE
perf(p5): change parameters on draw

### DIFF
--- a/src/view/matter/actors/character/animator/characterAnimator.ts
+++ b/src/view/matter/actors/character/animator/characterAnimator.ts
@@ -1,0 +1,53 @@
+import { CharacterDrawer } from 'src/view/matter/actors/character/drawer/characterDrawer';
+
+/**
+ * CharacterDrawerのパラメターを変更して、
+ * キャラクターにアニメーション効果を付ける。
+ */
+export abstract class CharacterAnimator {
+  private isStarted: boolean = false;
+
+  private startAt: number = 0;
+
+  /**
+   * @param duration アニメーションにかかる時間(ミリ秒)
+   * @param callback アニメーション開始、終了のタイミングで呼ばれるコールバック関数。
+   */
+  constructor(
+    protected readonly duration: number,
+    private readonly callback: {
+      onStart?: () => void,
+      onEnd?: () => void,
+    },
+  ) {
+  }
+
+  /**
+   * P5などの描画タイミングで、この関数を呼ぶと、
+   * 経過時間に応じて、アニメーションを実行する。
+   */
+  animate(drawer: CharacterDrawer) {
+    const { onStart, onEnd } = this.callback;
+    if (!this.isStarted) {
+      this.isStarted = true;
+      this.startAt = Date.now();
+      if (onStart) onStart();
+    }
+
+    const timeElapsed = Date.now() - this.startAt;
+    if (timeElapsed > this.duration) {
+      if (onEnd) onEnd();
+      // アニメーション終了のタイミングでアニメーションを実行する。
+      this.onAnimate(drawer, this.duration);
+      return;
+    }
+    this.onAnimate(drawer, timeElapsed);
+  }
+
+  /**
+   * アニメーションを実装するクラスは、この関数の中で、パラメータを変更する。
+   * @param drawer パラメータを変更すると、CharacterDrawerが描画時に、そのパラメータに応じた描画を行う。
+   * @param timeElapsed アニメーションを開始してからの経過時間(ミリ秒)
+   */
+  protected abstract onAnimate(drawer: CharacterDrawer, timeElapsed: number): void;
+}

--- a/src/view/matter/actors/character/animator/characterFadeoutAnimator.ts
+++ b/src/view/matter/actors/character/animator/characterFadeoutAnimator.ts
@@ -1,0 +1,9 @@
+import { CharacterAnimator } from 'src/view/matter/actors/character/animator/characterAnimator';
+import { CharacterDrawer } from 'src/view/matter/actors/character/drawer/characterDrawer';
+
+export class CharacterFadeoutAnimator extends CharacterAnimator {
+  protected onAnimate(drawer: CharacterDrawer, timeElapsed: number) {
+    // eslint-disable-next-line no-param-reassign
+    drawer.opacity = 1 - (timeElapsed / this.duration);
+  }
+}

--- a/src/view/matter/actors/character/animator/characterPopoutAnimator.ts
+++ b/src/view/matter/actors/character/animator/characterPopoutAnimator.ts
@@ -1,0 +1,19 @@
+import { CharacterAnimator } from 'src/view/matter/actors/character/animator/characterAnimator';
+import { CharacterDrawer } from 'src/view/matter/actors/character/drawer/characterDrawer';
+
+export class CharacterPopoutAnimator extends CharacterAnimator {
+  private static scale(x: number, duration: number, maxScale: number) {
+    // 小数をある程度切り捨てる
+    const rX: number = Math.round(x * 100) / 100;
+    const rM: number = Math.round(maxScale * 10) / 10;
+    const a: number = -(4 * rM - 4) / duration ** 2;
+    const b: number = (4 * rM - 4) / duration;
+    const c: number = 1;
+    return a * rX ** 2 + b * rX + c;
+  }
+
+  protected onAnimate(drawer: CharacterDrawer, timeElapsed: number) {
+    // eslint-disable-next-line no-param-reassign
+    drawer.scale = CharacterPopoutAnimator.scale(timeElapsed, this.duration, 1.5);
+  }
+}

--- a/src/view/matter/actors/character/characterFactory.ts
+++ b/src/view/matter/actors/character/characterFactory.ts
@@ -2,7 +2,7 @@ import { Character } from 'src/view/matter/actors/character/character';
 import { Bodies, Vector } from 'matter-js';
 import { CanvasParameter } from 'src/view/matter/models/canvasParameter';
 import P5Types from 'p5';
-import { CharacterDrawer } from 'src/view/matter/actors/character/characterDrawer';
+import { CharacterDrawer } from 'src/view/matter/actors/character/drawer/characterDrawer';
 
 enum CharacterSize {
   small = 80,

--- a/src/view/matter/actors/character/drawer/characterDrawer.ts
+++ b/src/view/matter/actors/character/drawer/characterDrawer.ts
@@ -12,12 +12,9 @@ export class CharacterDrawer {
 
   private static readonly senderNameTextSize = 14;
 
-  /**
-   * @param scale キャラクターの拡大率
-   * @param opacity キャラクターの透明度(0 ~ 1)
-   */
-  constructor(public scale: number, public opacity: number) {
-  }
+  public scale: number = 1.0;
+
+  public opacity: number = 1.0;
 
   static getColor({ character, opacity, p5 }:{
     character: Character,
@@ -83,7 +80,13 @@ export class CharacterDrawer {
     return 2 * rCosine * CharacterDrawer.scaleX;
   }
 
-  getEyePosition(character: Character): EyePosition {
+  draw(character: Character, p5: P5Types) {
+    this.drawBody(character, p5);
+    const { textBoxBottomY } = this.drawMessage(character, p5);
+    this.drawSenderName(character, p5, textBoxBottomY);
+  }
+
+  private getEyePosition(character: Character): EyePosition {
     const { position, radius } = character;
     return {
       left: Vector.create(
@@ -97,12 +100,12 @@ export class CharacterDrawer {
     };
   }
 
-  drawBody(character: Character, p5: P5Types) {
+  private drawBody(character: Character, p5: P5Types) {
     const { opacity, scale } = this;
 
     // 影の描画
     const colorShadow = p5.color('#004080');
-    colorShadow.setAlpha(1 / 100 * 255);
+    colorShadow.setAlpha(5 / 100 * 255);
 
     p5.push();
     p5.fill(colorShadow)
@@ -139,7 +142,7 @@ export class CharacterDrawer {
     p5.pop();
   }
 
-  drawMessage(character: Character, p5: P5Types): number {
+  private drawMessage(character: Character, p5: P5Types) {
     // textの描画
     const { message, radius } = character;
     const { scale, opacity } = this;
@@ -171,7 +174,7 @@ export class CharacterDrawer {
       );
     }
 
-    let bottomYPosition: number;
+    let textBoxBottomY: number;
     // 格納したtextの描画
     if (textLines.length === 1) {
       const { colorText } = CharacterDrawer.getColor({ character, p5, opacity });
@@ -179,7 +182,7 @@ export class CharacterDrawer {
         .textAlign('center', 'center')
         .textSize(messageTextSize * scale)
         .text(textLines[0], startPosition.x, startPosition.y);
-      bottomYPosition = startPosition.y + messageTextSize * scale;
+      textBoxBottomY = startPosition.y + messageTextSize * scale;
     } else {
       for (let i = 0; i < textLines.length; i += 1) {
         p5.fill(0)
@@ -187,13 +190,13 @@ export class CharacterDrawer {
           .textSize(messageTextSize * scale)
           .text(textLines[i], startPosition.x, startPosition.y + messageTextSize * scale * i);
       }
-      bottomYPosition = startPosition.y + messageTextSize * scale * textLines.length;
+      textBoxBottomY = startPosition.y + messageTextSize * scale * textLines.length;
     }
 
-    return bottomYPosition;
+    return { textBoxBottomY };
   }
 
-  drawSenderName(character: Character, p5: P5Types, textBoxBottomY: number) {
+  private drawSenderName(character: Character, p5: P5Types, textBoxBottomY: number) {
     const { position, sender } = character;
     const { scale, opacity } = this;
     const { colorSender } = CharacterDrawer.getColor({ character, p5, opacity });

--- a/src/view/matter/actors/character/types.ts
+++ b/src/view/matter/actors/character/types.ts
@@ -1,19 +1,5 @@
 import { Vector } from 'matter-js';
 
-export interface CharacterAction {
-  /**
-   * キャラクターをランダムな方向、速度で移動
-   */
-  moveSomeWhere(): void;
-
-  /**
-   * キャラクターをフェードアウトする。
-   * @param span フェードアウトが完了するまでにかかる時間(ミリ秒)
-   * @param onFadeOuted フェードアウト完了時のコールバック関数
-   */
-  fadeout(span: number, onFadeOuted: ()=> void | undefined): void
-}
-
 export type EyePosition = {
   left: Vector,
   right: Vector,

--- a/src/view/matter/controllers/characterController.ts
+++ b/src/view/matter/controllers/characterController.ts
@@ -34,10 +34,8 @@ export abstract class CharacterController {
       this.lastUpdateAt = current;
     }
 
-    character.popout(500, () => {
-      World.add(world, character.body);
-      this._characters.set(character.id, character);
-    });
+    this._characters.set(character.id, character);
+    character.popout(500, () => { World.add(world, character.body); });
   }
 
   remove(world: World, character: Character, { animate }: {animate: boolean} = { animate: true }) {


### PR DESCRIPTION
## 概要

### 修正の目的・解決したこと

今までのアニメーションの実装で利用していた
setIntervalはブラウザごとに性能のバラツキがあり、
すべてのブラウザで同じようにアニメーションすることができなかった。

この修正では、P5のdraw関数が呼ばれたタイミングで、パラメータの変更を行うことで、
setIntervalの性能に依存しない、アニメーションの実装になった。

### 変更の種類

- [x] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加 
- [ ] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)

### 関連する Issue