### PR TITLE
improve(topic): show notification when coping invitation

### DIFF
--- a/src/components/topic/actions/ChatAction.tsx
+++ b/src/components/topic/actions/ChatAction.tsx
@@ -9,6 +9,10 @@ type Props = {
   cartStyle?: boolean
 }
 
+/**
+ * メッセージ入力欄に表示されるアクションボタン
+ * isActive がtrueの場合は、ボタンがハイライトされる
+ */
 export const ChatAction: React.FC<Props> = ({
   children,
   message,

--- a/src/components/topic/actions/DeriveTopic.tsx
+++ b/src/components/topic/actions/DeriveTopic.tsx
@@ -5,6 +5,10 @@ import { useDispatch } from 'react-redux';
 import { useChatState } from 'src/data/redux/chat/selector';
 import { closeDeriveTopicDialog, showDeriveTopicDialog } from 'src/data/redux/chat/slice';
 
+/**
+ * メッセージ入力欄に表示されるアクションボタンの一つで、
+ * 話題の派生を行う。
+ */
 export const DeriveTopic = () => {
   const dispatcher = useDispatch();
   const { dialog } = useChatState();

--- a/src/components/topic/dialog/ChatActionBottomSheet.tsx
+++ b/src/components/topic/dialog/ChatActionBottomSheet.tsx
@@ -26,11 +26,13 @@ import { fadeinAnimation, slideY } from 'src/components/common/Animations';
 type Props = {
   isVisible: boolean,
   onClose: () => void,
+  onCopyInvitation: () => void,
 }
 
 export const ChatActionBottomSheet = ({
   isVisible,
   onClose,
+  onCopyInvitation,
 }: Props) => {
   const router = useRouter();
   const dispatcher = useDispatch();
@@ -73,7 +75,7 @@ export const ChatActionBottomSheet = ({
                     ログを表示
                     <ChatBubbleIcon />
                   </BottomSheetAction>
-                  <CopyToClipboard text={invitation ?? ''} onCopy={onClose}>
+                  <CopyToClipboard text={invitation ?? ''} onCopy={onCopyInvitation}>
                     <BottomSheetAction>
                       招待をコピー
                       <CopyIcon />

--- a/src/components/topic/dialog/ChatActionDialog.tsx
+++ b/src/components/topic/dialog/ChatActionDialog.tsx
@@ -12,15 +12,20 @@ import { useRouter } from 'next/router';
 type Props = {
   isVisible: boolean,
   onClose: () => void,
+  onCopyInvitation: () => void,
 }
 
 export const ChatActionDialog = ({
   isVisible,
+  onCopyInvitation,
   onClose,
 }: Props) => {
   const router = useRouter();
   const { topicId } = useChatState();
   const { invitation, isEditable } = useChatState();
+
+  if (!isVisible) return (<></>);
+
   return (
     <>
       <FullscreenContainer
@@ -32,7 +37,7 @@ export const ChatActionDialog = ({
         <Dialog>
           <CopyToClipboard
             text={invitation ?? ''}
-            onCopy={onClose}
+            onCopy={onCopyInvitation}
           >
             <li>招待をコピー</li>
           </CopyToClipboard>

--- a/src/data/redux/chat/slice.ts
+++ b/src/data/redux/chat/slice.ts
@@ -11,6 +11,7 @@ const initialState: ChatState = {
     deriveTopicDialog: false,
     branchTopicDialog: false,
     messageLog: false,
+    detailAction: false,
   },
   invitation: null,
   invitationCode: null,
@@ -31,6 +32,9 @@ const slice = createSlice({
 
     showMessageLog: (state) => { state.dialog.messageLog = true; },
     closeMessageLog: (state) => { state.dialog.messageLog = false; },
+
+    showDetailActionDialog: (state) => { state.dialog.detailAction = true; },
+    closeDetailActionDialog: (state) => { state.dialog.detailAction = false; },
 
     notify: (state, { payload }: ShowNotification) => {
       state.notification = {
@@ -94,6 +98,9 @@ export const {
 
   showMessageLog,
   closeMessageLog,
+
+  showDetailActionDialog,
+  closeDetailActionDialog,
 
   notify,
   clearNotification,

--- a/src/data/redux/chat/state.ts
+++ b/src/data/redux/chat/state.ts
@@ -22,6 +22,7 @@ export type ChatState = {
     deriveTopicDialog: boolean,
     branchTopicDialog: boolean,
     messageLog: boolean,
+    detailAction: boolean,
   }
 }
 


### PR DESCRIPTION
## 概要

### 修正の目的・解決したこと
詳細ダイアログから招待をコピーしたときに、
それを伝える通知を表示。
また、詳細ダイアログの表示状態をReduxで管理できるようにした。

### スクリーンショット
![image](https://user-images.githubusercontent.com/55840281/132499968-377004c1-f181-4a53-a868-55a8d6c6ffcf.png)

### 変更の種類

- [ ] バグの修正 (破壊的でない変更)
- [ ] 新しい機能の追加 
- [x] 改善 (クリーンアップや機能改善)
- [ ] 破壊的な修正 (既存の機能を修正する必要があるもの)

### 関連する Issue
